### PR TITLE
smartbasic: preprocessor: add support for #cmpifand

### DIFF
--- a/smartbasic.sublime-syntax
+++ b/smartbasic.sublime-syntax
@@ -31,7 +31,7 @@ contexts:
       push: line_comment
 
     # Preprocessor: SmartBASIC preprocessor-like tokens
-    - match: "(?i)^\\s*(#)\\s*\\b(define|include|set|cmpif|if)\\b"
+    - match: "(?i)^\\s*(#)\\s*\\b(define|include|set|cmpif|cmpifand|if)\\b"
       captures: 
         1: keyword.control.include.smartbasic
         2: keyword.control.include.smartbasic


### PR DESCRIPTION
This PR will add syntax highlighting support for the #cmpifand preprocessor directive to this project. It is available and used in smartBASIC, see https://github.com/LairdCP/BL654-Applications/blob/master/ATinterface/$LIB$.AT.interface.sb for example.